### PR TITLE
fix footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ const App = () => {
   const isButtonDisabled = reviewedName.trim() === "";
 
   return (
-    <div className="gmain-body">
+    <div className="main-body">
       <Navbar />
       <div className="layout m-4">
         <div className="container narrow-container mt-6">


### PR DESCRIPTION
There was a small typo in that class name.

Previously
<img width="1291" alt="Screenshot 2022-12-20 at 11 48 19" src="https://user-images.githubusercontent.com/10399364/208649375-79b72f19-7918-41d2-8827-09f3473020d4.png">

^^ notice the footer is hugging the content, so it's not fixed to the bottom of the page

With the fix
<img width="970" alt="Screenshot 2022-12-20 at 11 48 09" src="https://user-images.githubusercontent.com/10399364/208649437-2f032969-020b-4f0d-8f07-572ff0125c7d.png">
