### PR TITLE
moved modal state to different zustand file

### DIFF
--- a/src/components/DepartmentEditor.tsx
+++ b/src/components/DepartmentEditor.tsx
@@ -1,4 +1,4 @@
-import { useAppState } from "../state/state";
+import { useAppState } from "../state/app.state";
 
 export const DepartmentEditor = () => {
   const inputEnabled = useAppState((state) => state.inputEnabled);

--- a/src/components/MoreAttributes.tsx
+++ b/src/components/MoreAttributes.tsx
@@ -1,19 +1,20 @@
-import { FormEvent, useState } from "react";
+import { useState } from "react";
 import { generateUUID } from "../business/utils";
 import {
   AllAttributeDefinitions,
   getAttributeDescription,
 } from "../state/defaults";
-import { useAppState } from "../state/state";
+import { useAppState } from "../state/app.state";
 import { WorkAttribute } from "../business/common";
+import { useModalState } from "../state/modal.state";
 
 const AttributeModal = () => {
-  const selectedType = useAppState(
-    (state) => state.attributeModal.selectedType
+  const selectedType = useModalState(
+    (state) => state.selectedType
   );
-  const isOpened = useAppState((state) => state.attributeModal.isOpened);
+  const isOpened = useModalState((state) => state.isOpened);
   const addAttribute = useAppState((state) => state.addAttribute);
-  const closeAttributeModal = useAppState((state) => state.closeAttributeModal);
+  const closeAttributeModal = useModalState((state) => state.closeAttributeModal);
 
   const [text, setText] = useState("");
 
@@ -87,7 +88,7 @@ const AttributeModal = () => {
 export const MoreAttributes = () => {
   const inputEnabled = useAppState((state) => state.inputEnabled);
 
-  const openAttributeModal = useAppState((state) => state.openAttributeModal);
+  const openAttributeModal = useModalState((state) => state.openAttributeModal);
   const attributes = useAppState((state) => state.inputs.attributes);
   const removeAttribute = useAppState((state) => state.removeAttribute);
 

--- a/src/components/NameEditor.tsx
+++ b/src/components/NameEditor.tsx
@@ -1,4 +1,4 @@
-import { useAppState } from "../state/state";
+import { useAppState } from "../state/app.state";
 
 export const NameEditor = () => {
   const inputEnabled = useAppState((state) => state.inputEnabled);

--- a/src/components/PerformanceScoreEditor.tsx
+++ b/src/components/PerformanceScoreEditor.tsx
@@ -1,4 +1,4 @@
-import { useAppState } from "../state/state";
+import { useAppState } from "../state/app.state";
 import { PerformanceScore } from "../business/common";
 
 export const PerformanceScoreEditor = () => {

--- a/src/components/ResultBlock.tsx
+++ b/src/components/ResultBlock.tsx
@@ -1,4 +1,4 @@
-import { AppStatus, useAppState } from "../state/state";
+import { AppStatus, useAppState } from "../state/app.state";
 
 export const ResultBlock = () => {
   const answer = useAppState((state) => state.answer);

--- a/src/components/ReviewHeader.tsx
+++ b/src/components/ReviewHeader.tsx
@@ -1,4 +1,4 @@
-import { useAppState } from "../state/state";
+import { useAppState } from "../state/app.state";
 
 export const ReviewHeader = () => {
   const inputEnabled = useAppState((state) => state.inputEnabled);

--- a/src/components/RoleEditor.tsx
+++ b/src/components/RoleEditor.tsx
@@ -1,4 +1,4 @@
-import { useAppState } from "../state/state";
+import { useAppState } from "../state/app.state";
 
 export const RoleEditor = () => {
   const inputEnabled = useAppState((state) => state.inputEnabled);

--- a/src/components/SubmitControl.tsx
+++ b/src/components/SubmitControl.tsx
@@ -1,4 +1,4 @@
-import { useAppState } from "../state/state";
+import { useAppState } from "../state/app.state";
 
 export const SubmitControl = () => {
   const inputEnabled = useAppState((state) => state.inputEnabled);

--- a/src/state/app.state.ts
+++ b/src/state/app.state.ts
@@ -3,7 +3,6 @@ import create from "zustand";
 import {
   PerformanceScore,
   WorkAttribute,
-  WorkAttributeType,
 } from "../business/common";
 
 export enum AppStatus {
@@ -12,11 +11,6 @@ export enum AppStatus {
 }
 
 export type Result = string;
-
-interface AttributeModalState {
-  isOpened: boolean;
-  selectedType?: WorkAttributeType;
-}
 
 interface ReviewInputs {
   name: string;
@@ -31,7 +25,6 @@ interface AppState {
   inputEnabled: boolean;
   inputs: ReviewInputs;
   answer: Result;
-  attributeModal: AttributeModalState;
   clearInputs: () => void;
   updateName: (name: string) => void;
   updateRole: (role: string) => void;
@@ -39,8 +32,6 @@ interface AppState {
   updatePerformanceScore: (score: PerformanceScore) => void;
   addAttribute: (attribute: WorkAttribute) => void;
   removeAttribute: (attribute: WorkAttribute) => void;
-  openAttributeModal: (type: WorkAttributeType) => void;
-  closeAttributeModal: () => void;
   generateAnswer: (
     name: string,
     performanceScore: PerformanceScore,
@@ -132,26 +123,6 @@ export const useAppState = create<AppState>()((set) => ({
       return {
         ...state,
         inputs,
-      };
-    }),
-  openAttributeModal: (type: WorkAttributeType) =>
-    set((state) => {
-      return {
-        ...state,
-        attributeModal: {
-          isOpened: true,
-          selectedType: type,
-        },
-      };
-    }),
-  closeAttributeModal: () =>
-    set((state) => {
-      return {
-        ...state,
-        attributeModal: {
-          isOpened: false,
-          selectedType: undefined,
-        },
       };
     }),
   generateAnswer: async (

--- a/src/state/defaults.ts
+++ b/src/state/defaults.ts
@@ -1,4 +1,4 @@
-import { Result } from "./state";
+import { Result } from "./app.state";
 import { WorkAttributeType } from "../business/common";
 
 export type AttributeDefinition = {

--- a/src/state/modal.state.ts
+++ b/src/state/modal.state.ts
@@ -1,0 +1,30 @@
+import { WorkAttributeType } from '../business/common';
+import create from "zustand";
+
+export interface AttributeModalState {
+  isOpened: boolean;
+  selectedType?: WorkAttributeType;
+  openAttributeModal: (type: WorkAttributeType) => void;
+  closeAttributeModal: () => void;
+};
+
+export const useModalState = create<AttributeModalState>()((set) => ({
+  isOpened: false,
+  selectedType: undefined,
+  openAttributeModal: (type: WorkAttributeType) =>
+    set((state) => {
+      return {
+        ...state,
+        isOpened: true,
+        selectedType: type,
+      };
+    }),
+  closeAttributeModal: () =>
+    set((state) => {
+      return {
+        ...state,
+        isOpened: false,
+        selectedType: undefined,
+      };
+    }),
+}));


### PR DESCRIPTION
Just a refactor piece: moved the modal popup state into its own thing.
Renamed the file that contains the main state as `app.state.ts`, so that's why there's so many files changed.