### PR TITLE
Added more copy

### DIFF
--- a/src/components/MoreAttributes.tsx
+++ b/src/components/MoreAttributes.tsx
@@ -95,6 +95,10 @@ export const MoreAttributes = () => {
   const attributes = useAppState((state) => state.inputs.attributes);
   const removeAttribute = useAppState((state) => state.removeAttribute);
 
+  const showsEncouragementCopy = useAppState(
+    (state) => state.inputs.attributes.length === 0
+  );
+
   return (
     <div>
       <label className="label">Add more attributes (optional):</label>
@@ -110,7 +114,16 @@ export const MoreAttributes = () => {
           </button>
         ))}
       </div>
-      <AttributeModal />
+      {showsEncouragementCopy && (
+        <article className="message">
+          <div className="message-body">
+            You can optionally add more details by clicking the buttons above.
+            Adding such details like the skills and strengths of your colleague,
+            the projects they worked on or areas they need to improve on will
+            help create a better, more personalised, performance review.
+          </div>
+        </article>
+      )}
       <div className="tags">
         {attributes.map((attr) => (
           <span
@@ -126,6 +139,7 @@ export const MoreAttributes = () => {
           </span>
         ))}
       </div>
+      <AttributeModal />
     </div>
   );
 };


### PR DESCRIPTION
Added explainer copy for the attributes. 

<img width="987" alt="Screenshot 2022-12-23 at 14 45 48" src="https://user-images.githubusercontent.com/10399364/209346033-ad9b9eca-fecd-4d55-b018-5279e0696cdb.png">

We can alternatively think of a place to add this copy earlier on, mentioning all optional fields, not just the attributes.