### PR TITLE
improve outputs

### DIFF
--- a/src/business/common.ts
+++ b/src/business/common.ts
@@ -93,24 +93,24 @@ export interface ResumeInput {
     address: string;
     phone: string;
     email: string;
-    result: string[];
+    result: AIResult[];
   };
   summary: {
     question: string;
     history: WorkHistory;
     skills: string;
     summary: string;
-    result: string[];
+    result: AIResult[];
   };
   workplaces: {
     question: string;
     items: ResumeWorkHistory[];
-    result: string[];
+    result: AIResult[];
   };
   education: {
     question: string;
     items: ResumeEducationHistory[];
-    result: string[];
+    result: AIResult[];
   };
 }
 
@@ -126,3 +126,9 @@ export enum WorkHistory {
   Nine = "9",
   TenPlus = "10+",
 }
+
+export type AIResult = {
+  value: string;
+  editable: boolean;
+  joined: boolean;
+};

--- a/src/components/results/ResultsComponent.tsx
+++ b/src/components/results/ResultsComponent.tsx
@@ -1,11 +1,12 @@
 import * as bulmaToast from "bulma-toast";
 import { Analytics } from "../../business/analytics";
+import { AIResult } from "../../business/common";
 import { OpenAIService } from "../../business/open-ai.service";
 import { useResultState, formResult } from "../../state/result-state";
 import { AutoTextArea } from "../common/AutoTextArea";
 
 export const ResultsComponent = (props: {
-  onGenerateClick: () => Promise<string[]>;
+  onGenerateClick: () => Promise<AIResult[]>;
   generateButtonTitle?: string;
 }) => {
   const loading = useResultState((state) => state.loading);
@@ -84,19 +85,26 @@ export const ResultsComponent = (props: {
             <div
               className={
                 i === 0
-                  ? "top-content"
+                  ? res.joined
+                    ? "top-content no-bottom"
+                    : "top-content"
                   : i === results.length - 1
                   ? "bottom-content"
+                  : res.joined
+                  ? "normal-content no-bottom"
                   : "normal-content"
               }
             >
               <div className="pt-5 pl-3 pr-3 pb-5">
                 <button
-                  disabled={loading || reloadedSection !== undefined}
+                  disabled={
+                    !res.editable || loading || reloadedSection !== undefined
+                  }
                   title="Let DeepReview automatically expand this section."
                   className={
                     "button is-white is-small has-text-info is-text " +
-                    (reloadedSection === i ? "is-loading" : "")
+                    (reloadedSection === i ? "is-loading" : "") +
+                    (!res.editable ? "is-not-visible" : "")
                   }
                   onClick={() => onExpandClick(res.expanded, i)}
                 >
@@ -106,7 +114,11 @@ export const ResultsComponent = (props: {
                   </span> */}
                 </button>
               </div>
-              <div className="big-div pt-5 pl-3 pr-3 pb-5">
+              <div
+                className={
+                  "big-div pt-5 pl-3 pr-3 " + (!res.joined ? "pb-5" : "")
+                }
+              >
                 <AutoTextArea
                   disabled={loading || reloadedSection === i}
                   index={i}
@@ -119,9 +131,14 @@ export const ResultsComponent = (props: {
               </div>
               <div className="pt-5 pl-3 pr-3 pb-5">
                 <button
-                  disabled={loading || reloadedSection !== undefined}
+                  disabled={
+                    !res.editable || loading || reloadedSection !== undefined
+                  }
                   title="Undo"
-                  className="button is-small is-white"
+                  className={
+                    "button is-small is-white " +
+                    (!res.editable ? "is-not-visible" : "")
+                  }
                   onClick={() => resetElement(i)}
                 >
                   <span className="icon is-small">
@@ -134,7 +151,10 @@ export const ResultsComponent = (props: {
               <button
                 disabled={loading || reloadedSection !== undefined}
                 title="Add new section"
-                className="button is-small is-rounded plus-button"
+                className={
+                  "button is-small is-rounded plus-button " +
+                  (!res.editable ? "is-not-visible" : "")
+                }
                 onClick={() => addElement(i)}
               >
                 <span className="icon is-small has-text-success">

--- a/src/index.css
+++ b/src/index.css
@@ -227,6 +227,14 @@ a.underlined-style {
   border-bottom: 1px dashed lightgrey;
 }
 
+.no-bottom {
+  display: flex;
+  border-left: 1px solid lightgrey;
+  border-right: 1px solid lightgrey;
+  margin-top: -13px;
+  border-bottom: none;
+}
+
 .bottom-content {
   display: flex;
   border-left: 1px solid lightgrey;
@@ -242,4 +250,8 @@ a.underlined-style {
   height: 0px;
   border-bottom: 1px dashed hsl(0, 0%, 71%);
   /* has-text-grey-light */
+}
+
+.is-not-visible {
+  visibility: hidden;
 }

--- a/src/pages/performance-review/PerformanceReviewPage.tsx
+++ b/src/pages/performance-review/PerformanceReviewPage.tsx
@@ -4,6 +4,7 @@ import { Footer } from "../../components/common/Footer";
 import { SubscribeFrom } from "../../components/subscribe/SubscribeForm";
 import { usePerformanceReviewState } from "../../state/perf-review.state";
 import {
+  AIResult,
   PerformanceReviewInput,
   PerformanceScore,
   Pronouns,
@@ -59,7 +60,7 @@ export const PerformanceReviewPage = () => {
   const question = usePerformanceReviewState((state) => state.question);
   const setQuestion = usePerformanceReviewState((state) => state.setQuestion);
 
-  const onGenerateClick = async (): Promise<string[]> => {
+  const onGenerateClick = async (): Promise<AIResult[]> => {
     const input: PerformanceReviewInput = {
       relationship,
       question,

--- a/src/pages/resumes/CoverLetterPage.tsx
+++ b/src/pages/resumes/CoverLetterPage.tsx
@@ -5,7 +5,7 @@ import { NavbarMin } from "../../components/common/NavbarMin";
 import { SubscribeFrom } from "../../components/subscribe/SubscribeForm";
 import { useCoverLetterState } from "../../state/cover-letter.state";
 import { useResultState } from "../../state/result-state";
-import { CoverLetterInput, WorkHistory } from "../../business/common";
+import { AIResult, CoverLetterInput, WorkHistory } from "../../business/common";
 import { AutoTextArea } from "../../components/common/AutoTextArea";
 import { OpenAIService } from "../../business/open-ai.service";
 import { InputDetailsComponent } from "../../components/results/InputDetailsComponent";
@@ -27,7 +27,7 @@ export const CoverLetterPage = () => {
   const state = useCoverLetterState((state) => state);
   const details = useInputDetailsState((state) => state.details);
 
-  const onGenerateClick = async (): Promise<string[]> => {
+  const onGenerateClick = async (): Promise<AIResult[]> => {
     const input: CoverLetterInput = {
       question: state.question,
       company: state.company,

--- a/src/pages/resumes/ReferralPage.tsx
+++ b/src/pages/resumes/ReferralPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { Analytics, AnalyticsToolName } from "../../business/analytics";
-import { Pronouns, ReferralLetterInput } from "../../business/common";
+import { AIResult, Pronouns, ReferralLetterInput } from "../../business/common";
 import { OpenAIService } from "../../business/open-ai.service";
 import { AutoTextArea } from "../../components/common/AutoTextArea";
 import { ReferralLetterBreadcrumbs } from "../../components/common/Breadcrumbs";
@@ -26,7 +26,7 @@ export const ReferralPage = () => {
   const state = useReferralLetterState((state) => state);
   const details = useInputDetailsState((state) => state.details);
 
-  const onGenerateClick = async (): Promise<string[]> => {
+  const onGenerateClick = async (): Promise<AIResult[]> => {
     const input: ReferralLetterInput = {
       question: state.question,
       you: state.you,

--- a/src/state/result-state.ts
+++ b/src/state/result-state.ts
@@ -1,8 +1,11 @@
 import create from "zustand";
+import { AIResult } from "../business/common";
 
 export type OperationResult = {
   original: string;
   expanded: string;
+  editable: boolean;
+  joined: boolean;
 };
 
 export type ResultState = {
@@ -47,7 +50,9 @@ export const useResultState = create<ResultState>()((set) => ({
   addElement: (index: number) =>
     set((state) => {
       const results = state.results.flatMap((e, i) =>
-        i === index ? [e, { original: "", expanded: "" }] : [e]
+        i === index
+          ? [e, { original: "", expanded: "", editable: true, joined: false }]
+          : [e]
       );
       return { ...state, results };
     }),
@@ -61,7 +66,14 @@ export const useResultState = create<ResultState>()((set) => ({
   resetElement: (index: number) =>
     set((state) => {
       const results = state.results.map((e, i) =>
-        i === index ? { original: e.original, expanded: e.original } : e
+        i === index
+          ? {
+              original: e.original,
+              expanded: e.original,
+              editable: true,
+              joined: false,
+            }
+          : e
       );
       return { ...state, results };
     }),
@@ -79,5 +91,10 @@ export const useResultState = create<ResultState>()((set) => ({
     })),
 }));
 
-export const formResult = (initial: string[]): OperationResult[] =>
-  initial.map((original) => ({ original, expanded: original }));
+export const formResult = (initial: AIResult[]): OperationResult[] =>
+  initial.map((original) => ({
+    original: original.value,
+    expanded: original.value,
+    editable: original.editable,
+    joined: original.joined,
+  }));

--- a/src/state/resume.state.ts
+++ b/src/state/resume.state.ts
@@ -1,17 +1,17 @@
 import create from "zustand";
-import { WorkHistory } from "../business/common";
+import { AIResult, WorkHistory } from "../business/common";
 
 export type ResumeDetailsState = {
   name: string;
   address: string;
   phone: string;
   email: string;
-  result: string[];
+  result: AIResult[];
   setName: (name: string) => void;
   setAddress: (address: string) => void;
   setPhone: (phone: string) => void;
   setEmail: (email: string) => void;
-  setResult: (result: string[]) => void;
+  setResult: (result: AIResult[]) => void;
 };
 
 export type ResumeSummaryState = {
@@ -19,12 +19,12 @@ export type ResumeSummaryState = {
   history: WorkHistory;
   skills: string;
   summary: string;
-  result: string[];
+  result: AIResult[];
   setQuestion: (question: string) => void;
   setHistory: (history: WorkHistory) => void;
   setSkills: (skills: string) => void;
   setSummary: (summary: string) => void;
-  setResult: (result: string[]) => void;
+  setResult: (result: AIResult[]) => void;
 };
 
 export type ResumeWorkHistory = {
@@ -49,12 +49,12 @@ const NewWorkHistory = (): ResumeWorkHistory => ({
 export type ResumeHistoryState = {
   question: string;
   items: ResumeWorkHistory[];
-  result: string[];
+  result: AIResult[];
   setQuestion: (question: string) => void;
   addHistory: () => void;
   removeHistory: (index: number) => void;
   setHistory: (index: number, history: ResumeWorkHistory) => void;
-  setResult: (result: string[]) => void;
+  setResult: (result: AIResult[]) => void;
 };
 
 export type ResumeEducationHistory = {
@@ -79,12 +79,12 @@ const NewEducationHistory = (): ResumeEducationHistory => ({
 export type ResumeEducationState = {
   question: string;
   items: ResumeEducationHistory[];
-  result: string[];
+  result: AIResult[];
   setQuestion: (question: string) => void;
   addHistory: () => void;
   removeHistory: (index: number) => void;
   setHistory: (index: number, history: ResumeEducationHistory) => void;
-  setResult: (result: string[]) => void;
+  setResult: (result: AIResult[]) => void;
 };
 
 export enum ResumeStep {
@@ -109,7 +109,7 @@ export const useResumeDetailsState = create<ResumeDetailsState>()((set) => ({
   setAddress: (address: string) => set((state) => ({ ...state, address })),
   setPhone: (phone: string) => set((state) => ({ ...state, phone })),
   setEmail: (email: string) => set((state) => ({ ...state, email })),
-  setResult: (result: string[]) => set((state) => ({ ...state, result })),
+  setResult: (result: AIResult[]) => set((state) => ({ ...state, result })),
 }));
 
 export const useResumeSummaryState = create<ResumeSummaryState>()((set) => ({
@@ -123,7 +123,7 @@ export const useResumeSummaryState = create<ResumeSummaryState>()((set) => ({
   setHistory: (history: WorkHistory) => set((state) => ({ ...state, history })),
   setSkills: (skills: string) => set((state) => ({ ...state, skills })),
   setSummary: (summary: string) => set((state) => ({ ...state, summary })),
-  setResult: (result: string[]) => set((state) => ({ ...state, result })),
+  setResult: (result: AIResult[]) => set((state) => ({ ...state, result })),
 }));
 
 export const useResumeWorkHistoryState = create<ResumeHistoryState>()(
@@ -147,7 +147,7 @@ export const useResumeWorkHistoryState = create<ResumeHistoryState>()(
         const items = state.items.map((e, i) => (i === index ? history : e));
         return { ...state, items };
       }),
-    setResult: (result: string[]) => set((state) => ({ ...state, result })),
+    setResult: (result: AIResult[]) => set((state) => ({ ...state, result })),
   })
 );
 
@@ -173,7 +173,7 @@ export const useResumeEducationHistoryState = create<ResumeEducationState>()(
         const items = state.items.map((e, i) => (i === index ? history : e));
         return { ...state, items };
       }),
-    setResult: (result: string[]) => set((state) => ({ ...state, result })),
+    setResult: (result: AIResult[]) => set((state) => ({ ...state, result })),
   })
 );
 


### PR DESCRIPTION
A bit of a useful one, if a bit hacky. 

You know how we have the "Expand" button that adds more automatically generated details to each section of the response? 

That works OK, except when we have the Work & Education section of the Resume. Then the format is like this
<img width="957" alt="Screenshot 2023-02-02 at 16 34 13" src="https://user-images.githubusercontent.com/10399364/216384926-ea642c9a-c9f8-4d85-b438-354e52a7214b.png">

which looks nice, until you expand it, and it overrides that header part
<img width="949" alt="Screenshot 2023-02-02 at 16 34 18" src="https://user-images.githubusercontent.com/10399364/216385021-5b7b17f6-fd4e-404b-8957-407d6161afa8.png">

making "Expand" not be that useful for Resume. 

So the fix fixed this:
![localhost_3000_resume_cv (1)](https://user-images.githubusercontent.com/10399364/216385389-84595642-b14e-477e-b9cb-c98e12a60556.png)
![localhost_3000_resume_tool (1)](https://user-images.githubusercontent.com/10399364/216385555-7bd5215d-ea97-4aac-8acf-0957175a5e90.png)

by having editable and non-editable sections. 
The non-editable ones can't be expanded.  